### PR TITLE
Mac r home

### DIFF
--- a/get-r-mac.sh
+++ b/get-r-mac.sh
@@ -14,6 +14,13 @@ cat r.pkg/Payload | gunzip -dc | cpio -i
 mv R.framework/Versions/Current/Resources/* .
 rm -r r.pkg R.framework
 
+# Patch the main R script
+sed -i.bak '/^R_HOME_DIR=/d' r-mac/bin/R
+sed -i.bak 's;/Library/Frameworks/R.framework/Resources;${R_HOME};g' \
+    r-mac/bin/R
+chmod +x r-mac/bin/R
+rm -f r-mac/bin/R.bak
+
 # Remove unneccessary files TODO: What else
 rm -r doc tests
-rm -r lib/*.dSYM 
+rm -r lib/*.dSYM

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,7 @@ const startWebserver = async (attempt, progressCallback) => {
     ['--vanilla', '-e', rCode],
     { env: {
       'RHOME': rpath,
+      'R_HOME_DIR': rpath,
       'R_LIBS': libPath,
       'R_LIBS_USER': libPath,
       'R_LIBS_SITE': libPath,


### PR DESCRIPTION
The first commit can be removed if you're happy to drop using `Rscript` and just use `R` directly.  The second is more of a faff but looking at the output of `Sys.getenv()` and `.libPaths()` it looks like it might be working.  I've not tried actually compiling something with this R though!

The downside of this approach is that the bundled R _only_ works if one provides `R_HOME_DIR`. The upside is that it works.