### PR TITLE
Suppressed error causes createWindow to be called twice

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ const splashScreenOptions = {
 }
 
 const createSplashScreen = (filename) => {
-  const splashScreen = new BrowserWindow(splashScreenOptions)
+  let splashScreen = new BrowserWindow(splashScreenOptions)
   splashScreen.loadURL(`file://${__dirname}/${filename}.html`)
   splashScreen.on('closed', () => {
     splashScreen = null


### PR DESCRIPTION
This pull request fixes an error `TypeError: Assignment to constant variable.` which happens when `splashScreen.on('closed')`. 

The error was not propagates because it is caught silently in https://github.com/dirkschumacher/r-shiny-electron/blob/3db4e3cf299f7beae8df24361faba2996d07ad9e/src/index.js#L106 , which in turn causes the loop to iterate once more than needed.